### PR TITLE
feat: Allow passing an options object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { DynamoDBClient, GetItemCommand, PutItemCommand, UpdateItemCommand } fro
 import cookie from 'cookie';
 
 export interface SessionOptions {
-  ttlInMinutes: number //default 15 minutes
+  ttlInMinutes: number; //default 15 minutes
 }
 
 export class Session {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -136,34 +136,34 @@ describe('Setting options', () => {
     const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
     const session = new Session('', dynamoDBClient);
     expect(session.ttl).toBe(15);
-  })
-  
+  });
+
   test('Providing a ttl in constructor updates ttl', async () => {
     const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
     const session = new Session('', dynamoDBClient, { ttlInMinutes: 30 });
     expect(session.ttl).toBe(30);
-  })
+  });
 
   test('Providing a ttl in constructor passes ttl in request to dynamoDB', async () => {
     const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
     const session = new Session('', dynamoDBClient, { ttlInMinutes: 30 });
     await session.init();
-    
+
     const now = new Date();
     const ThirtyMinutesFromNow = Math.floor((now.getTime() / 1000) + 30 * 60);
 
-    await session.createSession({'test': { 'S': 'tst'}});
-    
+    await session.createSession({ test: { S: 'tst' } });
+
     // Grab the PutItemInput from the createSession call.
     const putItemInput = ddbMock.mock.calls[0][0].input as any;
     const ttl = putItemInput.Item.ttl.N;
 
-    // To prevent failing the test because both timestamps are calculated at different times 
+    // To prevent failing the test because both timestamps are calculated at different times
     // allow a second of difference.
     expect(Math.abs(parseInt(ttl) - ThirtyMinutesFromNow)).toBeLessThanOrEqual(1);
 
     expect(session.ttl).toBe(30);
-  })
+  });
 });
 
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -143,6 +143,27 @@ describe('Setting options', () => {
     const session = new Session('', dynamoDBClient, { ttlInMinutes: 30 });
     expect(session.ttl).toBe(30);
   })
+
+  test('Providing a ttl in constructor passes ttl in request to dynamoDB', async () => {
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+    const session = new Session('', dynamoDBClient, { ttlInMinutes:   });
+    await session.init();
+    
+    const now = new Date();
+    const ThirtyMinutesFromNow = Math.floor((now.getTime() / 1000) + 30 * 60);
+
+    await session.createSession({'test': { 'S': 'tst'}});
+    
+    // Grab the PutItemInput from the createSession call.
+    const putItemInput = ddbMock.mock.calls[0][0].input as any;
+    const ttl = putItemInput.Item.ttl.N;
+
+    // To prevent failing the test because both timestamps are calculated at different times 
+    // allow a second of difference.
+    expect(Math.abs(parseInt(ttl) - ThirtyMinutesFromNow)).toBeLessThanOrEqual(1);
+
+    expect(session.ttl).toBe(30);
+  })
 });
 
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -56,9 +56,7 @@ describe('Given a valid loggedin Session', () => {
 
 
 describe('Given a valid not loggedin session', () => {
-
   test('Session is logged out', async () => {
-
     const getItemOutput: Partial<GetItemCommandOutput> = {
       Item: {
         data: {
@@ -131,6 +129,20 @@ describe('Given a session cookie', () => {
     }
     expect(ddbMock).toHaveBeenCalledTimes(0);
   });
+});
+
+describe('Setting options', () => {
+  test('default session length is 15 minutes', async () => {
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+    const session = new Session('', dynamoDBClient);
+    expect(session.ttl).toBe(15);
+  })
+  
+  test('Providing a ttl in constructor updates ttl', async () => {
+    const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
+    const session = new Session('', dynamoDBClient, { ttlInMinutes: 30 });
+    expect(session.ttl).toBe(30);
+  })
 });
 
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -146,7 +146,7 @@ describe('Setting options', () => {
 
   test('Providing a ttl in constructor passes ttl in request to dynamoDB', async () => {
     const dynamoDBClient = new DynamoDBClient({ region: 'eu-west-1' });
-    const session = new Session('', dynamoDBClient, { ttlInMinutes:   });
+    const session = new Session('', dynamoDBClient, { ttlInMinutes: 30 });
     await session.init();
     
     const now = new Date();


### PR DESCRIPTION
- adds configurable ttl

An optional third argument `sessionOptions` is added to the Session constructor. This currently has one allowed key: `ttlInMinutes`. If set, the default of 15 minutes is changed to this value.

Example:
```
 const session = new Session('session=asessioncookievalue', dynamoDBClient, { ttlInMinutes: 30 });
```