### PR TITLE
fix: Set cookie path to /

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,7 @@ export class Session {
     const cookieString = cookie.serialize('session', value, {
       httpOnly: true,
       secure: true,
+      path: '/', //make sure the cookie is set for all paths in the domain
     });
     return cookieString;
   }

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -192,3 +192,10 @@ test('creating a loggedin Session generates a new session id', async () => {
   expect(session.sessionId == sessionId).toBeFalsy();
   expect(session.sessionId).toBeTruthy();
 });
+
+describe('Session cookie', () => {
+  test('Cookies have the path set to /', async () => {
+    const session = new Session(`session=${sessionId}`, dynamoDBClient);
+    expect(session.getCookie()).toContain('Path=/');
+  });
+});


### PR DESCRIPTION
This sets the cookie path to /, making sure
1: That the cookie can be used for all paths on the (sub)domain 
2: That setting the cookie on a path that isn't / will not add the path to the cookie, allowing for two session cookies at once.
